### PR TITLE
Add Inter font and standardize heading weights

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <title>Тестирование DeepSeek</title>
   <link rel="stylesheet" href="style.css">
   <!-- Chart.js для построения диаграмм -->

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
   --color-muted: #f5f5f5;
   --max-width: 1000px;
   --spacing: 1rem;
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
 }
 
 body {
@@ -33,13 +33,14 @@ h1 {
   margin: 0;
   font-size: 2.5rem;
   color: var(--color-primary);
+  font-weight: 700;
 }
 
 h2 {
   margin: 0.5rem 0 1rem;
   font-size: 1.5rem;
   color: var(--color-secondary);
-  font-weight: normal;
+  font-weight: 600;
 }
 
 .hero__meta {


### PR DESCRIPTION
## Summary
- load Inter font from Google Fonts
- set Inter as the base font
- specify consistent weights for headings

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888b960c6b4832e914b5fbeabef3c36