### PR TITLE
Add vertical sidebar menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@
   --color-muted: #f5f5f5;
   --max-width: 1000px;
   --spacing: 1rem;
+  --nav-width: 12rem;
   font-family: 'Inter', Arial, sans-serif;
 }
 
@@ -19,6 +20,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  padding-left: var(--nav-width);
 }
 
 main {
@@ -74,24 +76,32 @@ main {
 }
 
 /* Навигация */
+
+/* Навигация */
 .navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--nav-width);
   background-color: var(--color-muted);
-  padding: 0.5rem 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .navbar__inner {
-  max-width: var(--max-width);
-  margin: 0 auto;
+  margin: 0;
   display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .navbar a {
-  margin: 0 0.5rem;
+  margin: 0 0 0.5rem 0;
   color: var(--color-primary);
   text-decoration: none;
-  display: inline-block;
+  display: block;
   transition: color 0.2s ease-in-out;
 }
 

--- a/style_fuu.css
+++ b/style_fuu.css
@@ -8,6 +8,7 @@
   /* Увеличиваем максимальную ширину контейнера для уменьшения пустых полей */
   --max-width: 1200px;
   --spacing: 1rem;
+  --nav-width: 12rem;
   font-family: 'Inter', Arial, sans-serif;
 }
 
@@ -20,6 +21,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  padding-left: var(--nav-width);
 }
 
 main {
@@ -70,16 +72,29 @@ h2 {
 
 /* Навигация */
 .navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--nav-width);
   background-color: var(--color-muted);
-  padding: 0.5rem 1rem;
-  text-align: center;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.navbar__inner {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .navbar a {
-  margin: 0 0.5rem;
+  margin: 0 0 0.5rem 0;
   color: var(--color-primary);
   text-decoration: none;
-  display: inline-block;
+  display: block;
   transition: color 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
- add `--nav-width` variable and menu left padding
- convert navbar to a fixed vertical sidebar
- apply same sidebar changes to alternative stylesheet

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888d66baf6c832ea9e0e3c3171e650e