### PR TITLE
Add universal border-box sizing

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -11,6 +11,10 @@
   font-family: 'Inter', Arial, sans-serif;
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   background-color: var(--color-background);


### PR DESCRIPTION
## Summary
- apply border-box sizing to prevent layout overflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688915a2c1b4832ea59faa5bd7ddda24